### PR TITLE
Adwaita Colours

### DIFF
--- a/lib/colors/adwaita.d
+++ b/lib/colors/adwaita.d
@@ -44,11 +44,11 @@ enum Color brown3  = {152, 106,  68, 255};
 enum Color brown4  = {134,  94,  60, 255};
 enum Color brown5  = { 99,  69,  44, 255};
 
-enum Color light1  = {, 255};
-enum Color light2  = {, 255};
-enum Color light3  = {, 255};
-enum Color light4  = {, 255};
-enum Color light5  = {, 255};
+enum Color light1  = {255, 255, 255, 255};
+enum Color light2  = {246, 245, 244, 255};
+enum Color light3  = {222, 221, 218, 255};
+enum Color light4  = {192, 191, 188, 255};
+enum Color light5  = {154, 153, 150, 255};
 
 enum Color dark1   = {, 255};
 enum Color dark2   = {, 255};

--- a/lib/colors/adwaita.d
+++ b/lib/colors/adwaita.d
@@ -2,16 +2,16 @@ module raylib_misc.colors.adwaita;
 import raylib;
 
 // Palette Colors
-enum Color blue1 = {153, 193, 241, 255};
-enum Color blue2 = { 98, 160, 234, 255};
-enum Color blue3 = { 53, 132, 228, 255};
-enum Color blue4 = { 28, 113, 216, 255};
-enum Color blue5 = { 26,  95, 180, 255};
-enum Color 
-enum Color 
-enum Color 
-enum Color 
-enum Color 
+enum Color blue1  = {153, 193, 241, 255};
+enum Color blue2  = { 98, 160, 234, 255};
+enum Color blue3  = { 53, 132, 228, 255};
+enum Color blue4  = { 28, 113, 216, 255};
+enum Color blue5  = { 26,  95, 180, 255};
+enum Color green1 = {143, 240, 164, 255};
+enum Color green2 = { 87, 227, 137, 255};
+enum Color green3 = { 51, 209, 122, 255};
+enum Color green4 = { 46, 194, 126, 255};
+enum Color green5 = { 38, 162, 105, 255};
 enum Color 
 enum Color 
 enum Color 

--- a/lib/colors/adwaita.d
+++ b/lib/colors/adwaita.d
@@ -57,6 +57,10 @@ alias popoverBGDark  = thumbnailBGDark;
 alias popoverFGLight = windowFGLight;
 alias popoverFGDark  = light1;
 
+// Helper Colours
+enum Color regular(Color c)      = {c.r, c.g, c.b,  38};
+enum Color highContrast(Color c) = {c.r, c.g, c.b, 128};
+
 // Accent Colours
 enum Color accentLight   = { 28, 113, 216, 255};
 enum Color accentDark    = {120, 174, 237, 255};

--- a/lib/colors/adwaita.d
+++ b/lib/colors/adwaita.d
@@ -57,34 +57,34 @@ enum Color dark4   = { 36,  31,  49, 255};
 enum Color dark5   = {  0,   0,   0, 255};
 
 // Miscellaneous Colors
-enum Color shadeLight           = {  0,   0,   0,  18};
-enum Color shadeDark            = {  0,   0,   0,  92};
-alias scrollbarOutlineLight     = light1;
-enum Color scrollbarOutlineDark = {  0,   0,   0, 128};
+enum Color shadeLight            = {  0,   0,   0,  18};
+enum Color shadeDark             = {  0,   0,   0,  92};
+alias scrollbarOutlineLight      = light1;
+enum Color scrollbarOutlineDark  = {  0,   0,   0, 128};
 
 // Window Colours
-enum Color windowBGLight = {250, 250, 250, 255};
-enum Color windowBGDark  = { 36,  36,  36, 255};
-enum Color windowFGLight = {  0,   0,   0, 204};
-alias windowFGDark       = light1;
+enum Color windowBGLight         = {250, 250, 250, 255};
+enum Color windowBGDark          = { 36,  36,  36, 255};
+enum Color windowFGLight         = {  0,   0,   0, 204};
+alias windowFGDark               = light1;
 
 // View Colours
-alias viewBGLight     = light1;
-enum Color viewBGDark = { 30,  30,  30, 255};
-alias viewFGLight     = windowFGLight;
-alias viewFGDark      = light1;
+alias viewBGLight                = light1;
+enum Color viewBGDark            = { 30,  30,  30, 255};
+alias viewFGLight                = windowFGLight;
+alias viewFGDark                 = light1;
 
 // Headerbar Colours
-enum Color headerbarBGLight  = {235, 235, 235, 255};
-enum Color headerbarBGDark   = { 48,  48,  48, 255};
-alias headerbarFGLight       = windowFGLight;
-alias headerbarFGDark        = light1;
-alias headerbarBorderLight   = windowFGLight;
-alias headerbarBorderDark    = light1;
-alias headerbarBackdropLight = windowBGLight;
-alias headerbarBackdropDark  = windowBGDark;
-alias headerbarShadeLight    = shadeLight;
-alias headerbarShadeDark     = shadeDark;
+enum Color headerbarBGLight      = {235, 235, 235, 255};
+enum Color headerbarBGDark       = { 48,  48,  48, 255};
+alias headerbarFGLight           = windowFGLight;
+alias headerbarFGDark            = light1;
+alias headerbarBorderLight       = windowFGLight;
+alias headerbarBorderDark        = light1;
+alias headerbarBackdropLight     = windowBGLight;
+alias headerbarBackdropDark      = windowBGDark;
+alias headerbarShadeLight        = shadeLight;
+alias headerbarShadeDark         = shadeDark;
 
 // Sidebar Colours
 alias sidebarBGLight             = headerbarBGLight;
@@ -105,71 +105,71 @@ alias sidebar2ShadeLight         = shadeLight;
 alias sidebar2ShadeDark          = shadeDark;
 
 // Card Colours
-alias cardBGLight     = light1;
-enum Color cardBGDark = {255, 255, 255,  20};
-alias cardFGLight     = windowFGLight;
-alias cardFGDark      = light1;
-alias cardShadeLight  = shadeLight;
-alias cardShadeDark   = shadeDark;
+alias cardBGLight                = light1;
+enum Color cardBGDark            = {255, 255, 255,  20};
+alias cardFGLight                = windowFGLight;
+alias cardFGDark                 = light1;
+alias cardShadeLight             = shadeLight;
+alias cardShadeDark              = shadeDark;
 
 // Thumbnail Colours
-alias thumbnailBGLight     = light1;
-enum Color thumbnailBGDark = { 56,  56,  56, 255};
-alias thumbnailFGLight     = windowFGLight;
-alias thumbnailFGDark      = light1;
+alias thumbnailBGLight           = light1;
+enum Color thumbnailBGDark       = { 56,  56,  56, 255};
+alias thumbnailFGLight           = windowFGLight;
+alias thumbnailFGDark            = light1;
 
 // Dialog Colours
-alias dialogBGLight = light1;
-alias dialogBGDark  = thumbnailBGDark;
-alias dialogFGLight = windowFGLight;
-alias dialogFGDark  = light1;
+alias dialogBGLight              = light1;
+alias dialogBGDark               = thumbnailBGDark;
+alias dialogFGLight              = windowFGLight;
+alias dialogFGDark               = light1;
 
 // Popover Colours
-alias popoverBGLight = light1;
-alias popoverBGDark  = thumbnailBGDark;
-alias popoverFGLight = windowFGLight;
-alias popoverFGDark  = light1;
+alias popoverBGLight             = light1;
+alias popoverBGDark              = thumbnailBGDark;
+alias popoverFGLight             = windowFGLight;
+alias popoverFGDark              = light1;
 
 // Helper Colours
 enum Color regular(Color c)      = {c.r, c.g, c.b,  38};
 enum Color highContrast(Color c) = {c.r, c.g, c.b, 128};
 
 // Accent Colours
-enum Color accentLight   = { 28, 113, 216, 255};
-enum Color accentDark    = {120, 174, 237, 255};
-enum Color accentBGLight = { 53, 132, 228, 255};
-alias accentBGDark  = accentBGLight;
-alias accentFGLight = light1;
-alias accentFGDark  = light1;
+enum Color accentLight           = { 28, 113, 216, 255};
+enum Color accentDark            = {120, 174, 237, 255};
+enum Color accentBGLight         = { 53, 132, 228, 255};
+alias accentBGDark               = accentBGLight;
+alias accentFGLight              = light1;
+alias accentFGDark               = light1;
 
 // Destructive Colours
-enum Color destructiveLight   = {192,  28,  40, 255};
-enum Color destructiveDark    = {255, 123,  99, 255};
-enum Color destructiveBGLight = {224,  27,  36, 255};
-alias destructiveBGDark  = destructiveLight;
-alias destructiveFGLight = light1;
-alias destructiveFGDark  = light1;
+enum Color destructiveLight      = {192,  28,  40, 255};
+enum Color destructiveDark       = {255, 123,  99, 255};
+enum Color destructiveBGLight    = {224,  27,  36, 255};
+alias destructiveBGDark          = destructiveLight;
+alias destructiveFGLight         = light1;
+alias destructiveFGDark          = light1;
 
 // Success Colours
-enum Color successLight   = { 27, 133,  83, 255};
-enum Color successDark    = {143, 240, 164, 255};
-enum Color successBGLight = { 46, 194, 126, 255};
-enum Color successBGDark  = { 38, 162, 105, 255};
-alias successFGLight = light1;
-alias successFGDark  = light1;
+enum Color successLight          = { 27, 133,  83, 255};
+enum Color successDark           = {143, 240, 164, 255};
+enum Color successBGLight        = { 46, 194, 126, 255};
+enum Color successBGDark         = { 38, 162, 105, 255};
+alias successFGLight             = light1;
+alias successFGDark              = light1;
 
 // Warning Colours
-enum Color warningLight   = {156, 110,   3, 255};
-enum Color warningDark    = {248, 228,  92, 255};
-enum Color warningBGLight = {229, 165,  10, 255};
-enum Color warningBGDark  = {205, 147,   9, 255};
-alias warningFGLight = windowFGLight;
-alias warningFGDark  = warningFGLight;
+enum Color warningLight          = {156, 110,   3, 255};
+enum Color warningDark           = {248, 228,  92, 255};
+enum Color warningBGLight        = {229, 165,  10, 255};
+enum Color warningBGDark         = {205, 147,   9, 255};
+alias warningFGLight             = windowFGLight;
+alias warningFGDark              = warningFGLight;
 
 // Error Colours
-alias errorLight   = destructiveLight;
-alias errorDark    = destructiveDark;
-alias errorBGLight = destructiveBGLight;
-alias errorBGDark  = destructiveBGDark;
-alias errorFGLight = destructiveFGLight;
-alias errorFGDark  = destructiveFGDark;
+alias errorLight                 = destructiveLight;
+alias errorDark                  = destructiveDark;
+alias errorBGLight               = destructiveBGLight;
+alias errorBGDark                = destructiveBGDark;
+alias errorFGLight               = destructiveFGLight;
+alias errorFGDark                = destructiveFGDark;

--- a/lib/colors/adwaita.d
+++ b/lib/colors/adwaita.d
@@ -25,11 +25,12 @@ enum Color orange2 = {255, 163,  72, 255};
 enum Color orange3 = {255, 120,   0, 255};
 enum Color orange4 = {230,  97,   0, 255};
 enum Color orange5 = {198,  70,   0, 255};
-enum Color 
-enum Color 
-enum Color 
-enum Color 
-enum Color 
+
+enum Color red1    = {246,  97,  81, 255};
+enum Color red2    = {237,  51,  59, 255};
+enum Color red3    = {224,  27,  36, 255};
+enum Color red4    = {192,  28,  40, 255};
+enum Color red5    = {165,  29,  45, 255};
 enum Color 
 enum Color 
 enum Color 

--- a/lib/colors/adwaita.d
+++ b/lib/colors/adwaita.d
@@ -1,10 +1,18 @@
-module raylib_misc.colors.web;
+module raylib_misc.colors.adwaita;
 import raylib;
 
 // Accent Colours
 enum Color accentLight   = { 28, 113, 216};
 enum Color accentDark    = {120, 174, 237};
 enum Color accentBGLight = { 53, 132, 228};
-enum Color accentBGDark  = accentLight;
+enum Color accentBGDark  = accentBGLight;
 enum Color accentFGLight = light1;
 enum Color accentFGDark  = light1;
+
+// Destructive Colours
+enum Color destructiveLight   = {192,  28,  40};
+enum Color destructiveDark    = {255, 123,  99};
+enum Color destructiveBGLight = {224,  27,  36};
+enum Color destructiveBGDark  = destructiveLight;
+enum Color destructiveFGLight = light1;
+enum Color destructiveFGDark  = light1;

--- a/lib/colors/adwaita.d
+++ b/lib/colors/adwaita.d
@@ -25,6 +25,20 @@ alias headerbarBackdropDark    = windowBGDark;
 enum Color headerbarShadeLight = {  0,   0,   0,  18};
 enum Color headerbarShadeDark  = {  0,   0,   0,  92};
 
+// Card Colours
+alias cardBGLight     = light1;
+enum Color cardBGDark = {255, 255, 255,  20};
+alias cardFGLight     = windowFGLight;
+alias cardFGDark      = light1;
+alias cardShadeLight  = headerbarShadeLight;
+alias cardShadeDark   = headerbarShadeDark;
+
+// Thumbnail Colours
+alias thumbnailBGLight     = light1;
+enum Color thumbnailBGDark = { 56,  56,  56, 255};
+alias thumbnailFGLight     = windowFGLight;
+alias thumbnailFGDark      = light1;
+
 // Accent Colours
 enum Color accentLight   = { 28, 113, 216, 255};
 enum Color accentDark    = {120, 174, 237, 255};

--- a/lib/colors/adwaita.d
+++ b/lib/colors/adwaita.d
@@ -24,3 +24,11 @@ enum Color successBGLight = { 46, 194, 126, 255};
 enum Color successBGDark  = { 38, 162, 105, 255};
 alias successFGLight = light1;
 alias successFGDark  = light1;
+
+// Warning Colours
+enum Color warningLight   = {156, 110,   3, 255};
+enum Color warningDark    = {248, 228,  92, 255};
+enum Color warningBGLight = {229, 165,  10, 255};
+enum Color warningBGDark  = {205, 147,   9, 255};
+enum Color warningFGLight = {  0,   0,   0, 204};
+alias warningFGDark  = warningFGLight;

--- a/lib/colors/adwaita.d
+++ b/lib/colors/adwaita.d
@@ -5,13 +5,25 @@ import raylib;
 enum Color windowBGLight = {250, 250, 250, 255};
 enum Color windowBGDark  = { 36,  36,  36, 255};
 enum Color windowFGLight = {  0,   0,   0, 204};
-alias windowFGDark = light1;
+alias windowFGDark       = light1;
 
 // View Colours
-alias viewBGLight = light1;
+alias viewBGLight     = light1;
 enum Color viewBGDark = { 30,  30,  30, 255};
-alias viewFGLight = windowFGLight;
-alias viewFGDark  = light1;
+alias viewFGLight     = windowFGLight;
+alias viewFGDark      = light1;
+
+// Headerbar Colours
+enum Color headerbarBGLight    = {235, 235, 235, 255};
+enum Color headerbarBGDark     = { 48,  48,  48, 255};
+alias headerbarFGLight         = windowFGLight;
+alias headerbarFGDark          = light1;
+alias headerbarBorderLight     = windowFGLight;
+alias headerbarBorderDark      = light1;
+alias headerbarBackdropLight   = windowBGLight;
+alias headerbarBackdropDark    = windowBGDark;
+enum Color headerbarShadeLight = {  0,   0,   0,  18};
+enum Color headerbarShadeDark  = {  0,   0,   0,  92};
 
 // Accent Colours
 enum Color accentLight   = { 28, 113, 216, 255};

--- a/lib/colors/adwaita.d
+++ b/lib/colors/adwaita.d
@@ -5,22 +5,22 @@ import raylib;
 enum Color accentLight   = { 28, 113, 216, 255};
 enum Color accentDark    = {120, 174, 237, 255};
 enum Color accentBGLight = { 53, 132, 228, 255};
-enum Color accentBGDark  = accentBGLight;
-enum Color accentFGLight = light1;
-enum Color accentFGDark  = light1;
+alias accentBGDark  = accentBGLight;
+alias accentFGLight = light1;
+alias accentFGDark  = light1;
 
 // Destructive Colours
 enum Color destructiveLight   = {192,  28,  40, 255};
 enum Color destructiveDark    = {255, 123,  99, 255};
 enum Color destructiveBGLight = {224,  27,  36, 255};
-enum Color destructiveBGDark  = destructiveLight;
-enum Color destructiveFGLight = light1;
-enum Color destructiveFGDark  = light1;
+alias destructiveBGDark  = destructiveLight;
+alias destructiveFGLight = light1;
+alias destructiveFGDark  = light1;
 
 // Success Colours
 enum Color successLight   = { 27, 133,  83, 255};
 enum Color successDark    = {143, 240, 164, 255};
 enum Color successBGLight = { 46, 194, 126, 255};
 enum Color successBGDark  = { 38, 162, 105, 255};
-enum Color successFGLight = light1;
-enum Color successFGDark  = light1;
+alias successFGLight = light1;
+alias successFGDark  = light1;

--- a/lib/colors/adwaita.d
+++ b/lib/colors/adwaita.d
@@ -31,27 +31,30 @@ enum Color red2    = {237,  51,  59, 255};
 enum Color red3    = {224,  27,  36, 255};
 enum Color red4    = {192,  28,  40, 255};
 enum Color red5    = {165,  29,  45, 255};
-enum Color 
-enum Color 
-enum Color 
-enum Color 
-enum Color 
-enum Color 
-enum Color 
-enum Color 
-enum Color 
-enum Color 
-enum Color 
-enum Color 
-enum Color 
-enum Color 
-enum Color 
-enum Color 
-enum Color 
-enum Color 
-enum Color 
-enum Color 
-enum Color 
+
+enum Color purple1 = {220, 138, 221, 255};
+enum Color purple2 = {192,  97, 203, 255};
+enum Color purple3 = {145,  65, 172, 255};
+enum Color purple4 = {129,  61, 156, 255};
+enum Color purple5 = { 97,  53, 131, 255};
+
+enum Color brown1  = {, 255};
+enum Color brown2  = {, 255};
+enum Color brown3  = {, 255};
+enum Color brown4  = {, 255};
+enum Color brown5  = {, 255};
+
+enum Color light1  = {, 255};
+enum Color light2  = {, 255};
+enum Color light3  = {, 255};
+enum Color light4  = {, 255};
+enum Color light5  = {, 255};
+
+enum Color dark1   = {, 255};
+enum Color dark2   = {, 255};
+enum Color dark3   = {, 255};
+enum Color dark4   = {, 255};
+enum Color dark5   = {, 255};
 
 // Miscellaneous Colors
 enum Color shadeLight           = {  0,   0,   0,  18};

--- a/lib/colors/adwaita.d
+++ b/lib/colors/adwaita.d
@@ -2,17 +2,25 @@ module raylib_misc.colors.adwaita;
 import raylib;
 
 // Accent Colours
-enum Color accentLight   = { 28, 113, 216};
-enum Color accentDark    = {120, 174, 237};
-enum Color accentBGLight = { 53, 132, 228};
+enum Color accentLight   = { 28, 113, 216, 255};
+enum Color accentDark    = {120, 174, 237, 255};
+enum Color accentBGLight = { 53, 132, 228, 255};
 enum Color accentBGDark  = accentBGLight;
 enum Color accentFGLight = light1;
 enum Color accentFGDark  = light1;
 
 // Destructive Colours
-enum Color destructiveLight   = {192,  28,  40};
-enum Color destructiveDark    = {255, 123,  99};
-enum Color destructiveBGLight = {224,  27,  36};
+enum Color destructiveLight   = {192,  28,  40, 255};
+enum Color destructiveDark    = {255, 123,  99, 255};
+enum Color destructiveBGLight = {224,  27,  36, 255};
 enum Color destructiveBGDark  = destructiveLight;
 enum Color destructiveFGLight = light1;
 enum Color destructiveFGDark  = light1;
+
+// Success Colours
+enum Color successLight   = { 27, 133,  83, 255};
+enum Color successDark    = {143, 240, 164, 255};
+enum Color successBGLight = { 46, 194, 126, 255};
+enum Color successBGDark  = { 38, 162, 105, 255};
+enum Color successFGLight = light1;
+enum Color successFGDark  = light1;

--- a/lib/colors/adwaita.d
+++ b/lib/colors/adwaita.d
@@ -50,11 +50,11 @@ enum Color light3  = {222, 221, 218, 255};
 enum Color light4  = {192, 191, 188, 255};
 enum Color light5  = {154, 153, 150, 255};
 
-enum Color dark1   = {, 255};
-enum Color dark2   = {, 255};
-enum Color dark3   = {, 255};
-enum Color dark4   = {, 255};
-enum Color dark5   = {, 255};
+enum Color dark1   = {119, 118, 123, 255};
+enum Color dark2   = { 94,  92, 100, 255};
+enum Color dark3   = { 61,  56,  70, 255};
+enum Color dark4   = { 36,  31,  49, 255};
+enum Color dark5   = {  0,   0,   0, 255};
 
 // Miscellaneous Colors
 enum Color shadeLight           = {  0,   0,   0,  18};

--- a/lib/colors/adwaita.d
+++ b/lib/colors/adwaita.d
@@ -2,21 +2,21 @@ module raylib_misc.colors.adwaita;
 import raylib;
 
 // Palette Colors
-enum Color blue1  = {153, 193, 241, 255};
-enum Color blue2  = { 98, 160, 234, 255};
-enum Color blue3  = { 53, 132, 228, 255};
-enum Color blue4  = { 28, 113, 216, 255};
-enum Color blue5  = { 26,  95, 180, 255};
-enum Color green1 = {143, 240, 164, 255};
-enum Color green2 = { 87, 227, 137, 255};
-enum Color green3 = { 51, 209, 122, 255};
-enum Color green4 = { 46, 194, 126, 255};
-enum Color green5 = { 38, 162, 105, 255};
-enum Color 
-enum Color 
-enum Color 
-enum Color 
-enum Color 
+enum Color blue1   = {153, 193, 241, 255};
+enum Color blue2   = { 98, 160, 234, 255};
+enum Color blue3   = { 53, 132, 228, 255};
+enum Color blue4   = { 28, 113, 216, 255};
+enum Color blue5   = { 26,  95, 180, 255};
+enum Color green1  = {143, 240, 164, 255};
+enum Color green2  = { 87, 227, 137, 255};
+enum Color green3  = { 51, 209, 122, 255};
+enum Color green4  = { 46, 194, 126, 255};
+enum Color green5  = { 38, 162, 105, 255};
+enum Color yellow1 = {249, 240, 107, 255};
+enum Color yellow2 = {248, 228,  92, 255};
+enum Color yellow3 = {246, 211,  45, 255};
+enum Color yellow4 = {245, 194,  17, 255};
+enum Color yellow5 = {229, 165,  10, 255};
 enum Color 
 enum Color 
 enum Color 

--- a/lib/colors/adwaita.d
+++ b/lib/colors/adwaita.d
@@ -1,6 +1,12 @@
 module raylib_misc.colors.adwaita;
 import raylib;
 
+// Miscellaneous Colors
+enum Color shadeLight           = {  0,   0,   0,  18};
+enum Color shadeDark            = {  0,   0,   0,  92};
+alias scrollbarOutlineLight     = light1;
+enum Color scrollbarOutlineDark = {  0,   0,   0, 128};
+
 // Window Colours
 enum Color windowBGLight = {250, 250, 250, 255};
 enum Color windowBGDark  = { 36,  36,  36, 255};
@@ -14,24 +20,24 @@ alias viewFGLight     = windowFGLight;
 alias viewFGDark      = light1;
 
 // Headerbar Colours
-enum Color headerbarBGLight    = {235, 235, 235, 255};
-enum Color headerbarBGDark     = { 48,  48,  48, 255};
-alias headerbarFGLight         = windowFGLight;
-alias headerbarFGDark          = light1;
-alias headerbarBorderLight     = windowFGLight;
-alias headerbarBorderDark      = light1;
-alias headerbarBackdropLight   = windowBGLight;
-alias headerbarBackdropDark    = windowBGDark;
-enum Color headerbarShadeLight = {  0,   0,   0,  18};
-enum Color headerbarShadeDark  = {  0,   0,   0,  92};
+enum Color headerbarBGLight  = {235, 235, 235, 255};
+enum Color headerbarBGDark   = { 48,  48,  48, 255};
+alias headerbarFGLight       = windowFGLight;
+alias headerbarFGDark        = light1;
+alias headerbarBorderLight   = windowFGLight;
+alias headerbarBorderDark    = light1;
+alias headerbarBackdropLight = windowBGLight;
+alias headerbarBackdropDark  = windowBGDark;
+alias headerbarShadeLight    = shadeLight;
+alias headerbarShadeDark     = shadeDark;
 
 // Card Colours
 alias cardBGLight     = light1;
 enum Color cardBGDark = {255, 255, 255,  20};
 alias cardFGLight     = windowFGLight;
 alias cardFGDark      = light1;
-alias cardShadeLight  = headerbarShadeLight;
-alias cardShadeDark   = headerbarShadeDark;
+alias cardShadeLight  = shadeLight;
+alias cardShadeDark   = shadeDark;
 
 // Thumbnail Colours
 alias thumbnailBGLight     = light1;

--- a/lib/colors/adwaita.d
+++ b/lib/colors/adwaita.d
@@ -1,6 +1,12 @@
 module raylib_misc.colors.adwaita;
 import raylib;
 
+// Window Colours
+enum Color windowBGLight   = {250, 250, 250, 255};
+enum Color windowBGDark    = { 36,  36,  36, 255};
+enum Color windowFGLight = {  0,   0,   0, 204};
+alias windowFGDark  = light1;
+
 // Accent Colours
 enum Color accentLight   = { 28, 113, 216, 255};
 enum Color accentDark    = {120, 174, 237, 255};
@@ -30,7 +36,7 @@ enum Color warningLight   = {156, 110,   3, 255};
 enum Color warningDark    = {248, 228,  92, 255};
 enum Color warningBGLight = {229, 165,  10, 255};
 enum Color warningBGDark  = {205, 147,   9, 255};
-enum Color warningFGLight = {  0,   0,   0, 204};
+alias warningFGLight = windowFGLight;
 alias warningFGDark  = warningFGLight;
 
 // Error Colours

--- a/lib/colors/adwaita.d
+++ b/lib/colors/adwaita.d
@@ -2,10 +2,16 @@ module raylib_misc.colors.adwaita;
 import raylib;
 
 // Window Colours
-enum Color windowBGLight   = {250, 250, 250, 255};
-enum Color windowBGDark    = { 36,  36,  36, 255};
+enum Color windowBGLight = {250, 250, 250, 255};
+enum Color windowBGDark  = { 36,  36,  36, 255};
 enum Color windowFGLight = {  0,   0,   0, 204};
-alias windowFGDark  = light1;
+alias windowFGDark = light1;
+
+// View Colours
+alias viewBGLight = light1;
+enum Color viewBGDark = { 30,  30,  30, 255};
+alias viewFGLight = windowFGLight;
+alias viewFGDark  = light1;
 
 // Accent Colours
 enum Color accentLight   = { 28, 113, 216, 255};

--- a/lib/colors/adwaita.d
+++ b/lib/colors/adwaita.d
@@ -92,7 +92,7 @@ alias sidebarBGDark              = headerbarFGDark;
 alias sidebarFGLight             = windowFGLight;
 alias sidebarFGDark              = light1;
 enum Color sidebarBackdropLight  = {242, 242, 242, 255};
-enum Color sidebarBackdropDark   = { 42,  42,  42};
+enum Color sidebarBackdropDark   = { 42,  42,  42, 255};
 alias sidebarShadeLight          = shadeLight;
 alias sidebarShadeDark           = shadeDark;
 enum Color sidebar2BGLight       = {243, 243, 243, 255};
@@ -143,16 +143,16 @@ alias accentFGLight              = light1;
 alias accentFGDark               = light1;
 
 // Destructive Colours
-enum Color destructiveLight      = {192,  28,  40, 255};
+alias destructiveLight           = red4;
 enum Color destructiveDark       = {255, 123,  99, 255};
-enum Color destructiveBGLight    = {224,  27,  36, 255};
+alias destructiveBGLight         = red3;
 alias destructiveBGDark          = destructiveLight;
 alias destructiveFGLight         = light1;
 alias destructiveFGDark          = light1;
 
 // Success Colours
 enum Color successLight          = { 27, 133,  83, 255};
-enum Color successDark           = {143, 240, 164, 255};
+alias successDark                = green1;
 enum Color successBGLight        = { 46, 194, 126, 255};
 enum Color successBGDark         = { 38, 162, 105, 255};
 alias successFGLight             = light1;
@@ -161,7 +161,7 @@ alias successFGDark              = light1;
 // Warning Colours
 enum Color warningLight          = {156, 110,   3, 255};
 enum Color warningDark           = {248, 228,  92, 255};
-enum Color warningBGLight        = {229, 165,  10, 255};
+alias warningBGLight             = yellow5;
 enum Color warningBGDark         = {205, 147,   9, 255};
 alias warningFGLight             = windowFGLight;
 alias warningFGDark              = warningFGLight;

--- a/lib/colors/adwaita.d
+++ b/lib/colors/adwaita.d
@@ -1,6 +1,54 @@
 module raylib_misc.colors.adwaita;
 import raylib;
 
+// Palette Colors
+enum Color blue1 = {153, 193, 241, 255};
+enum Color blue2 = { 98, 160, 234, 255};
+enum Color blue3 = { 53, 132, 228, 255};
+enum Color blue4 = { 28, 113, 216, 255};
+enum Color blue5 = { 26,  95, 180, 255};
+enum Color 
+enum Color 
+enum Color 
+enum Color 
+enum Color 
+enum Color 
+enum Color 
+enum Color 
+enum Color 
+enum Color 
+enum Color 
+enum Color 
+enum Color 
+enum Color 
+enum Color 
+enum Color 
+enum Color 
+enum Color 
+enum Color 
+enum Color 
+enum Color 
+enum Color 
+enum Color 
+enum Color 
+enum Color 
+enum Color 
+enum Color 
+enum Color 
+enum Color 
+enum Color 
+enum Color 
+enum Color 
+enum Color 
+enum Color 
+enum Color 
+enum Color 
+enum Color 
+enum Color 
+enum Color 
+enum Color 
+enum Color 
+
 // Miscellaneous Colors
 enum Color shadeLight           = {  0,   0,   0,  18};
 enum Color shadeDark            = {  0,   0,   0,  92};

--- a/lib/colors/adwaita.d
+++ b/lib/colors/adwaita.d
@@ -1,0 +1,10 @@
+module raylib_misc.colors.web;
+import raylib;
+
+// Accent Colours
+enum Color accentLight   = { 28, 113, 216};
+enum Color accentDark    = {120, 174, 237};
+enum Color accentBGLight = { 53, 132, 228};
+enum Color accentBGDark  = accentLight;
+enum Color accentFGLight = light1;
+enum Color accentFGDark  = light1;

--- a/lib/colors/adwaita.d
+++ b/lib/colors/adwaita.d
@@ -7,21 +7,24 @@ enum Color blue2   = { 98, 160, 234, 255};
 enum Color blue3   = { 53, 132, 228, 255};
 enum Color blue4   = { 28, 113, 216, 255};
 enum Color blue5   = { 26,  95, 180, 255};
+
 enum Color green1  = {143, 240, 164, 255};
 enum Color green2  = { 87, 227, 137, 255};
 enum Color green3  = { 51, 209, 122, 255};
 enum Color green4  = { 46, 194, 126, 255};
 enum Color green5  = { 38, 162, 105, 255};
+
 enum Color yellow1 = {249, 240, 107, 255};
 enum Color yellow2 = {248, 228,  92, 255};
 enum Color yellow3 = {246, 211,  45, 255};
 enum Color yellow4 = {245, 194,  17, 255};
 enum Color yellow5 = {229, 165,  10, 255};
-enum Color 
-enum Color 
-enum Color 
-enum Color 
-enum Color 
+
+enum Color orange1 = {255, 190, 111, 255};
+enum Color orange2 = {255, 163,  72, 255};
+enum Color orange3 = {255, 120,   0, 255};
+enum Color orange4 = {230,  97,   0, 255};
+enum Color orange5 = {198,  70,   0, 255};
 enum Color 
 enum Color 
 enum Color 

--- a/lib/colors/adwaita.d
+++ b/lib/colors/adwaita.d
@@ -38,11 +38,11 @@ enum Color purple3 = {145,  65, 172, 255};
 enum Color purple4 = {129,  61, 156, 255};
 enum Color purple5 = { 97,  53, 131, 255};
 
-enum Color brown1  = {, 255};
-enum Color brown2  = {, 255};
-enum Color brown3  = {, 255};
-enum Color brown4  = {, 255};
-enum Color brown5  = {, 255};
+enum Color brown1  = {205, 171, 143, 255};
+enum Color brown2  = {181, 131,  90, 255};
+enum Color brown3  = {152, 106,  68, 255};
+enum Color brown4  = {134,  94,  60, 255};
+enum Color brown5  = { 99,  69,  44, 255};
 
 enum Color light1  = {, 255};
 enum Color light2  = {, 255};

--- a/lib/colors/adwaita.d
+++ b/lib/colors/adwaita.d
@@ -39,6 +39,18 @@ enum Color thumbnailBGDark = { 56,  56,  56, 255};
 alias thumbnailFGLight     = windowFGLight;
 alias thumbnailFGDark      = light1;
 
+// Dialog Colours
+alias dialogBGLight = light1;
+alias dialogBGDark  = thumbnailBGDark;
+alias dialogFGLight = windowFGLight;
+alias dialogFGDark  = light1;
+
+// Popover Colours
+alias popoverBGLight = light1;
+alias popoverBGDark  = thumbnailBGDark;
+alias popoverFGLight = windowFGLight;
+alias popoverFGDark  = light1;
+
 // Accent Colours
 enum Color accentLight   = { 28, 113, 216, 255};
 enum Color accentDark    = {120, 174, 237, 255};

--- a/lib/colors/adwaita.d
+++ b/lib/colors/adwaita.d
@@ -31,6 +31,24 @@ alias headerbarBackdropDark  = windowBGDark;
 alias headerbarShadeLight    = shadeLight;
 alias headerbarShadeDark     = shadeDark;
 
+// Sidebar Colours
+alias sidebarBGLight             = headerbarBGLight;
+alias sidebarBGDark              = headerbarFGDark;
+alias sidebarFGLight             = windowFGLight;
+alias sidebarFGDark              = light1;
+enum Color sidebarBackdropLight  = {242, 242, 242, 255};
+enum Color sidebarBackdropDark   = { 42,  42,  42};
+alias sidebarShadeLight          = shadeLight;
+alias sidebarShadeDark           = shadeDark;
+enum Color sidebar2BGLight       = {243, 243, 243, 255};
+alias sidebar2BGDark             = sidebarBackdropDark;
+alias sidebar2FGLight            = windowFGLight;
+alias sidebar2FGDark             = light1;
+enum Color sidebar2BackdropLight = {246, 246, 246, 255};
+enum Color sidebar2BackdropDark  = { 39,  39,  39, 255};
+alias sidebar2ShadeLight         = shadeLight;
+alias sidebar2ShadeDark          = shadeDark;
+
 // Card Colours
 alias cardBGLight     = light1;
 enum Color cardBGDark = {255, 255, 255,  20};

--- a/lib/colors/adwaita.d
+++ b/lib/colors/adwaita.d
@@ -32,3 +32,11 @@ enum Color warningBGLight = {229, 165,  10, 255};
 enum Color warningBGDark  = {205, 147,   9, 255};
 enum Color warningFGLight = {  0,   0,   0, 204};
 alias warningFGDark  = warningFGLight;
+
+// Error Colours
+alias errorLight   = destructiveLight;
+alias errorDark    = destructiveDark;
+alias errorBGLight = destructiveBGLight;
+alias errorBGDark  = destructiveBGDark;
+alias errorFGLight = destructiveFGLight;
+alias errorFGDark  = destructiveFGDark;

--- a/lib/colors/package.d
+++ b/lib/colors/package.d
@@ -2,6 +2,7 @@ module raylib_misc.colors;
 public
 {
     import raylib_misc.colors.translucent;
+    import raylib_misc.colors.adwaita;
     import raylib_misc.colors.web;
     import raylib_misc.colors.x11;
 }


### PR DESCRIPTION
This PR adds libadwaita colours to the Colour Module.

Reasoning: the same reasoning for including x11 and web colours apply here; if one comes from a background where libadwaita is used often in their projects, then it will feel more comfortable with these definitions being readily available for use.

The colour definitions were taken from here:
https://gnome.pages.gitlab.gnome.org/libadwaita/doc/main/named-colors.html

do note that a prefix was not used here as it was with x11. This is intentional; a lot of libadwaita's colours have long names and none of those actually conflict with the main colour sub module.

btw the same guidelines from https://github.com/RealDoigt/Alien-Hack-D/blob/main/contributing.md apply here as well.